### PR TITLE
Logic to build before watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ Bug fixes are documented as being part of the "next release" but are made immedi
 
 # Releases
 
-#### 1.0.0 (Latest release)
+#### 1.1.0
+  - Adds `--skip-initial` flag to NOT build all the scss files when you first run node-sass-chokidar using the `--watch` flag.
+
+#### 1.0.0
  - Switches `--watch` behavior to build all files before watching. Fixes [#31]
  - Removes `--recursive` flag since it didn't do anything.
  - Adds a `--match-regex` option that takes a regex and will ignore all files not matching the regular expression. [#40] and [#24]
 
-#### 0.1.0 (Next Minor release)
+#### 0.1.0
  - Features
      - [#9](https://github.com/michaelwayman/node-sass-chokidar/issues/9) add support for node 8 thanks to @anmonteiro
  - Bug fixes

--- a/bin/node-sass-chokidar
+++ b/bin/node-sass-chokidar
@@ -48,6 +48,7 @@ var cli = meow({
     '  -i, --indented-syntax      Treat data from stdin as sass code (versus scss)',
     '  -q, --quiet                Suppress log output except on error',
     '  -v, --version              Prints version info',
+    '  -b, --build-first          Transpiles all SCSS before watching',
     '  --output-style             CSS output style (nested | expanded | compact | compressed)',
     '  --indent-type              Indent type for output CSS (space | tab)',
     '  --indent-width             Indent width; number of spaces or tabs (maximum value: 10)',
@@ -75,7 +76,8 @@ var cli = meow({
     'source-map-embed',
     'source-map-contents',
     'source-comments',
-    'watch'
+    'watch',
+    'build-first'
   ],
   string: [
     'functions',
@@ -96,7 +98,8 @@ var cli = meow({
     o: 'output',
     x: 'omit-source-map-url',
     v: 'version',
-    w: 'watch'
+    w: 'watch',
+    b: 'build-first'
   },
   default: {
     'include-path': process.cwd(),
@@ -349,12 +352,28 @@ function run(options, emitter) {
     }
   }
 
-  if (options.watch) {
+  if (options.watch && options.buildFirst) {
+    renderDirOrFile(options, emitter);
     watch(options, emitter);
-  } else if (options.directory) {
-    renderDir(options, emitter);
+  } else if (options.watch) {
+    watch(options, emitter);
   } else {
-    render(options, emitter);
+    renderDirOrFile(options, emitter);
+  }
+}
+
+/**
+ * Conditionally render a dir or file based on options
+ *
+ * @param {Object} options
+ * @param {Object} emitter
+ * @api private
+ */
+function renderDirOrFile(options, emitter) {
+  if (options.directory) {
+    renderDir(options, emitter)
+  } else {
+    render(options, emitter)
   }
 }
 
@@ -398,9 +417,11 @@ function renderDir(options, emitter) {
         renderFile(subject, options, emitter);
       }
     }, function(successful, arr) {
-      var outputDir = path.join(process.cwd(), options.output);
-      emitter.emit('warn', util.format('Wrote %s CSS files to %s', arr.length, outputDir));
-      process.exit();
+      if (!options.watch) {
+        var outputDir = path.join(process.cwd(), options.output);
+        emitter.emit('warn', util.format('Wrote %s CSS files to %s', arr.length, outputDir));
+        process.exit();
+      }
     });
   });
 }

--- a/bin/node-sass-chokidar
+++ b/bin/node-sass-chokidar
@@ -48,7 +48,7 @@ var cli = meow({
     '  -i, --indented-syntax      Treat data from stdin as sass code (versus scss)',
     '  -q, --quiet                Suppress log output except on error',
     '  -v, --version              Prints version info',
-    '  --skip-initial             Skips initial build when passed with --watch flag',
+    '  --skip-initial             Skips initial build when passing the --watch flag',
     '  --output-style             CSS output style (nested | expanded | compact | compressed)',
     '  --indent-type              Indent type for output CSS (space | tab)',
     '  --indent-width             Indent width; number of spaces or tabs (maximum value: 10)',
@@ -271,7 +271,8 @@ function watch(options, emitter) {
   }
 
   var watcher = chokidar.watch(paths, {
-    followSymlinks: options.follow
+    followSymlinks: options.follow,
+    ignoreInitial: options.skipInitial,
   });
 
   watcher.on('error', function(error) {

--- a/bin/node-sass-chokidar
+++ b/bin/node-sass-chokidar
@@ -48,7 +48,7 @@ var cli = meow({
     '  -i, --indented-syntax      Treat data from stdin as sass code (versus scss)',
     '  -q, --quiet                Suppress log output except on error',
     '  -v, --version              Prints version info',
-    '  -b, --build-first          Transpiles all SCSS before watching',
+    '  --skip-initial             Skips initial build when passed with --watch flag',
     '  --output-style             CSS output style (nested | expanded | compact | compressed)',
     '  --indent-type              Indent type for output CSS (space | tab)',
     '  --indent-width             Indent width; number of spaces or tabs (maximum value: 10)',
@@ -73,11 +73,11 @@ var cli = meow({
     'indented-syntax',
     'omit-source-map-url',
     'quiet',
+    'skip-initial',
     'source-map-embed',
     'source-map-contents',
     'source-comments',
-    'watch',
-    'build-first'
+    'watch'
   ],
   string: [
     'functions',
@@ -98,8 +98,7 @@ var cli = meow({
     o: 'output',
     x: 'omit-source-map-url',
     v: 'version',
-    w: 'watch',
-    b: 'build-first'
+    w: 'watch'
   },
   default: {
     'include-path': process.cwd(),
@@ -352,28 +351,8 @@ function run(options, emitter) {
     }
   }
 
-  if (options.watch && options.buildFirst) {
-    renderDirOrFile(options, emitter);
-    watch(options, emitter);
-  } else if (options.watch) {
-    watch(options, emitter);
-  } else {
-    renderDirOrFile(options, emitter);
-  }
-}
-
-/**
- * Conditionally render a dir or file based on options
- *
- * @param {Object} options
- * @param {Object} emitter
- * @api private
- */
-function renderDirOrFile(options, emitter) {
-  if (options.directory) {
-    renderDir(options, emitter)
-  } else {
-    render(options, emitter)
+  if (options.watch) {
+    watch(options, emitter)
   }
 }
 
@@ -417,11 +396,9 @@ function renderDir(options, emitter) {
         renderFile(subject, options, emitter);
       }
     }, function(successful, arr) {
-      if (!options.watch) {
-        var outputDir = path.join(process.cwd(), options.output);
-        emitter.emit('warn', util.format('Wrote %s CSS files to %s', arr.length, outputDir));
-        process.exit();
-      }
+      var outputDir = path.join(process.cwd(), options.output);
+      emitter.emit('warn', util.format('Wrote %s CSS files to %s', arr.length, outputDir));
+      process.exit();
     });
   });
 }

--- a/bin/node-sass-chokidar
+++ b/bin/node-sass-chokidar
@@ -354,6 +354,10 @@ function run(options, emitter) {
 
   if (options.watch) {
     watch(options, emitter);
+  } else if (options.directory) {
+    renderDir(options, emitter);
+  } else {
+    render(options, emitter);
   }
 }
 

--- a/bin/node-sass-chokidar
+++ b/bin/node-sass-chokidar
@@ -108,6 +108,7 @@ var cli = meow({
     'output-style': 'nested',
     precision: 5,
     quiet: false,
+    'skip-initial': false,
   }
 });
 
@@ -352,7 +353,7 @@ function run(options, emitter) {
   }
 
   if (options.watch) {
-    watch(options, emitter)
+    watch(options, emitter);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass-chokidar",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass-chokidar",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A thin wrapper around node-sass to replicate the --watch --recursive but with chokidar instead of Gaze",
   "bin": {
     "node-sass-chokidar": "bin/node-sass-chokidar"


### PR DESCRIPTION
Adds logic for new flag:

```-b, --build-first          Transpiles all SCSS before watching```

Providing this flag alongside `--watch` will result in the provided directory/file being transpiled before watching this path, alleviating the need for chaining these calls.

Example:
`node-sass-chokidar src/ -o src/ && node-sass-chokidar src/ -o src/ --watch --recursive` 
becomes
`node-sass-chokidar src/ -o src/ --watch --recursive -b`