### PR TITLE
chore(package): use node-sass 4.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "get-stdin": "^4.0.1",
     "glob": "^7.0.3",
     "meow": "^3.7.0",
-    "node-sass": "^4.9.2",
+    "node-sass": "^4.9.3",
     "sass-graph": "^2.1.1",
     "stdout-stream": "^1.4.0"
   },


### PR DESCRIPTION
4.9.3 release includes a fix for dependency (hoek) affected by CVE-2018-3728, see https://github.com/sass/node-sass/issues/2355 for details