### PR TITLE
Add `info` messages emitting same way it's in node-sass

### DIFF
--- a/bin/node-sass-chokidar
+++ b/bin/node-sass-chokidar
@@ -162,6 +162,12 @@
     }
   });
 
+  emitter.on('info', function (data) {
+    if (!options.quiet) {
+      console.info(data);
+    }
+  });
+
   emitter.on('log', stdout.write.bind(stdout));
 
   return emitter;


### PR DESCRIPTION
Handles `info` type of emitted messages.
Based on [node-sass binary file](https://github.com/sass/node-sass/blob/master/bin/node-sass#L164).